### PR TITLE
Force regular jump before wall jump

### DIFF
--- a/GrowingDepths/js/plugins/TMJumpAction.js
+++ b/GrowingDepths/js/plugins/TMJumpAction.js
@@ -2339,7 +2339,7 @@ function Game_Bullet() {
         var y = Math.floor(this._realY);
 
         //If you can wall jump, do it, otherwise regular jump (if you can), otherwise exit routine
-        if ($gameMap.canWallJump(x, y, this._direction)) {
+        if ($gameMap.canWallJump(x, y, this._direction) && this._jumpCount != this._mulchJump) {
           this.wallJump();
         } else if (this._jumpCount > 0 && this.jumpInputCountdown == 0) {
           this._jumpCount--;


### PR DESCRIPTION
Player cannot just walk up to a wall and start wall jumping, they must jump once before being able to wall jump. 
close #126 