### PR TITLE
Improve wall jump animation transition

### DIFF
--- a/GrowingDepths/js/plugins/TMJumpAction.js
+++ b/GrowingDepths/js/plugins/TMJumpAction.js
@@ -1384,7 +1384,7 @@ function Game_Bullet() {
           this.collideMapDown();
           this.collideCharacterDown();
           //"if travelling downwards, change character image"
-          if (this.isFalling()) {
+          if (this.isFalling() && !this.currentlyCanWallJump()) {
     	    this.changeAnimation(MCAnimation.FALLING);
           }
         } else {

--- a/GrowingDepths/js/plugins/TMJumpAction.js
+++ b/GrowingDepths/js/plugins/TMJumpAction.js
@@ -1634,6 +1634,11 @@ function Game_Bullet() {
 
   Game_CharacterBase.prototype.changeAnimation = function(RequestedAnimation) {
   	if (this._CurrentAnimation !== RequestedAnimation) {
+  		if (RequestedAnimation == MCAnimation.IDLE) {
+  			this.setStepAnime(true);
+  		} else {
+  			this.setStepAnime(false);
+  		}
     	this._CurrentAnimation = RequestedAnimation;
     	var CharacterSheetToLoad = MCAnimation.fileNames[RequestedAnimation]
     	$gameActors.actor(1).setCharacterImage(CharacterSheetToLoad, 1);


### PR DESCRIPTION
Character now doesn't leave the wall sliding state when falling.
Character now has a unique state transition to IDLE and can transition out of it correctly when the player moves.
RPG Maker MV will cycle through all sprites on the IDLE sprite sheet instead of holding a static frame (`setStepAnime(true)`)

commit against #186 
commit against #185 